### PR TITLE
fix invalid f-strings

### DIFF
--- a/src/aphyt/cip/cip.py
+++ b/src/aphyt/cip/cip.py
@@ -87,12 +87,12 @@ class CIPException(Exception):
         super().__init__(self.get_message())
 
     def get_message(self):
-        message = (f'\nCIP reply contained a general status code {binascii.hexlify(self.status).decode('utf-8')}\n'
-                   f'{cip_status_dictionary[self.status][0]}\n{cip_status_dictionary[self.status][1]}\n')
+        message = (f"\nCIP reply contained a general status code {binascii.hexlify(self.status).decode('utf-8')}\n"
+               f"{cip_status_dictionary[self.status][0]}\n{cip_status_dictionary[self.status][1]}\n")
 
         value = cip_status_dictionary.get(self.extended_status)
         if self.extended_status != b'':
-            message += f'Extended Status: {binascii.hexlify(self.extended_status).decode('utf-8')} \n'
+            message += f"Extended Status: {binascii.hexlify(self.extended_status).decode('utf-8')} \n"
         if value is not None:
             message += f'{value[0]}'
         return message


### PR DESCRIPTION
Found a bug in the latest version (0.1.25):

```
from aphyt import omron
  File "/usr/local/lib/python3.11/dist-packages/aphyt/omron/__init__.py", line 7, in <module>
    from .n_series import *
  File "/usr/local/lib/python3.11/dist-packages/aphyt/omron/n_series.py", line 16, in <module>
    from aphyt.eip import *
  File "/usr/local/lib/python3.11/dist-packages/aphyt/eip/__init__.py", line 6, in <module>
    from .eip import *
  File "/usr/local/lib/python3.11/dist-packages/aphyt/eip/eip.py", line 8, in <module>
    from aphyt.cip.cip import CIPReply, CIPRequest, AsyncCIPDispatcher, CIPDispatcher, CIPException
  File "/usr/local/lib/python3.11/dist-packages/aphyt/cip/cip.py", line 90
    message = (f'\nCIP reply contained a general status code {binascii.hexlify(self.status).decode('utf-8')}\n'
                                                                                                    ^^^
SyntaxError: f-string: unmatched '('
```

Issue is using nested single quotes within an f string. 